### PR TITLE
Fixed NotasRepository, notas, by adding missing self

### DIFF
--- a/src/repositories/notas_repository.py
+++ b/src/repositories/notas_repository.py
@@ -50,7 +50,7 @@ class NotasRepository:
 
     def notas(self, padron: str) -> List[Tuple[str, str]]:
         notas = self._get_sheet(self.SHEET_NOTAS)
-        filas = notas.get_values(RANGO_NOTAS, major_dimension="COLUMNS")
+        filas = notas.get_values(self.RANGO_NOTAS, major_dimension="COLUMNS")
         headers = filas.pop(0)
         idx_padron = headers.index(self.COL_PADRON)
 


### PR DESCRIPTION
En el PR #14 se introdujo un error donde faltaba un `self` para una constante en `NotasRepository`, en el método `notas`. Este PR lo resuelve.