### PR TITLE
replaced notas_email cc test email

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -119,7 +119,7 @@ def create_notas_mail(ejercicio: str, grupo: Grupo) -> Email:
         subject=f"Correccion de notas ejercicio {ejercicio} - Grupo {grupo.numero}",
         from_addr=f"Algoritmos3Leveroni <{EMAIL_ACCOUNT}>",
         to_addr=grupo.emails,
-        cc="josubouchard@gmail.com",
+        cc=DOCENTES_EMAIL,
         reply_to=f"Docentes Algoritmos 3 <{DOCENTES_EMAIL}>"
     )
     email.add_plaintext_content(


### PR DESCRIPTION
En #22 se cometio el error de dejar un mail personal en el CC de `create_notas_mail`. Este commit arregla ese error, reemplazandolo con el mail de la lista docente como deberia haber sido.