### PR TITLE
Hotfix: procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-gunicorn --time=180 --pythonpath './src' main:app
+web: gunicorn --time=180 --pythonpath './src' main:app

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn src/main:app --time=180
+gunicorn --time=180 --pythonpath './src' main:app


### PR DESCRIPTION
Hotfix del PR #34. Arregla el archivo `Procfile` para correr apropiadamente en heroku