### PR TITLE
Feature/emails improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,22 @@ $ pipenv install
 Crear un archivo llamado `.env` y poner los datos pertinentes:
 
 ```bash
+ENVIRONMENT='*****'
+
 NOTAS_COURSE_NAME='Algoritmos III - Leveroni'
-NOTAS_ACCOUNT='*****@gmail.com'
 NOTAS_SECRET='*****'
+
+ADMIN_USERNAME='*****'
+ADMIN_PASSWORD='*****'
+
+EMAIL_ACCOUNT='*****'
+EMAIL_PASSWORD='*****'
+EMAIL_SMTP_ADDRESS='*****'
+EMAIL_SMTP_PORT='*****'
+EMAIL_USE_SSL='*****'
+
+NOTAS_SERVICE_ACCOUNT_CREDENTIALS='*****'
 NOTAS_SPREADSHEET_KEY='*****'
-NOTAS_SERVICE_ACCOUNT_JSON='./service_account.json'
-NOTAS_OAUTH_CLIENT='*****'
-NOTAS_OAUTH_SECRET='*****'
-NOTAS_REFRESH_TOKEN='*****'
 ```
 
 Solo es necesario completar todos los campos en caso de que se desee la funcionalidad completa. Para más información, leer la sección *'Variables de entorno'* debajo.

--- a/src/config.py
+++ b/src/config.py
@@ -62,6 +62,18 @@ class EmailConfig(BaseConfig):
     def docentes_email(self) -> str:
         return self.get_config_variable("EMAIL_DOCENTES")
 
+    @property
+    def smtp_server_address(self) -> str:
+        return self.get_config_variable("EMAIL_SMTP_ADDRESS")
+
+    @property
+    def smtp_server_port(self) -> str:
+        return self.get_config_variable("EMAIL_SMTP_PORT")
+
+    @property
+    def use_ssl(self) -> bool:
+        return self.get_config_variable("EMAIL_USE_SSL").lower() == 'true'
+
 
 class SpreadsheetConfig(BaseConfig):
     @property

--- a/src/config.py
+++ b/src/config.py
@@ -17,7 +17,10 @@ class BaseConfig:
         self.config = {**self.config, **os.environ}
 
     def get_config_variable(self, name: str, default: Any = None):
-        return self.config.get(name, default)
+        config = self.config.get(name, default)
+        if config:
+            return config.strip()
+        return config
 
 
 class AppConfig(BaseConfig):

--- a/src/emails/emails.py
+++ b/src/emails/emails.py
@@ -6,16 +6,16 @@ from .abstract_mailable import AbstractMailable
 app_config = AppConfig()
 email_config = EmailConfig()
 
-
-def gmail_smtp_connection():
-    connection = smtplib.SMTP_SSL(host="smtp.gmail.com", port=465)
-    connection.login(user=email_config.account, password=email_config.password)
+def smtp_connection():
+    SMTPConnection = smtplib.SMTP_SSL if email_config.use_ssl else smtplib.SMTP
+    connection = SMTPConnection(
+        host=email_config.smtp_server_address,
+        port=int(email_config.smtp_server_port),
+    )
+    if email_config.account:
+        connection.login(user=email_config.account, password=email_config.password)
 
     return connection
-
-
-def mailhog_smtp_connection():
-    return smtplib.SMTP(host="localhost", port=1025)
 
 
 class Email(AbstractMailable):
@@ -35,15 +35,3 @@ class Email(AbstractMailable):
 
     def set_cc_to_lista_docente(self, should_send_copy: bool):
         return self.set_cc(email_config.docentes_email if should_send_copy else None)
-
-
-"""
-A variable to decide which smtp service to use.
-* Use `mailhog_smtp_connection` for testing purposes
-(first initialize mailhog)
-* Use `gmail_smtp_connection` for production
-"""
-if app_config.environment == "PRODUCTION":
-    smtp_connection = gmail_smtp_connection
-else:
-    smtp_connection = mailhog_smtp_connection

--- a/src/emails/emails.py
+++ b/src/emails/emails.py
@@ -12,7 +12,7 @@ def smtp_connection():
         host=email_config.smtp_server_address,
         port=int(email_config.smtp_server_port),
     )
-    if email_config.account:
+    if email_config.account and email_config.password:
         connection.login(user=email_config.account, password=email_config.password)
 
     return connection


### PR DESCRIPTION
Este PR permite la configuracion del servidor SMTP desde las variables de entorno, en vez de estar hardcodeado en el programa.

Las variables de entorno para emails entonces quedarian asi:

* `EMAIL_ACCOUNT`: el nombre de usuario / email del que se mandan las cosas
* `EMAIL_PASSWORD`: la contraseña del servidor SMTP
* `EMAIL_SMTP_ADDRESS`: la direccion del server SMTP
* `EMAIL_SMTP_PORT`: el puerto del server SMTP
* `EMAIL_USE_SSL`: un booleano que indica si usar `SMTP_SSL` o simplemente `SMTP`

Esto permite utilizar el servidor SMTP de gmail en produccion y un servidor de Mailtrap o Mailhog para desarrollo y testeo, y poder cambiarlo en cualquier momento sin necesidad de hacer otro PR.